### PR TITLE
docs(user): Fix links in Contributors.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,17 +4,17 @@
 
 ## Creator & Maintainer
 
-* Hamza Faran [@hfaran](github.com/hfaran)
+* Hamza Faran [@hfaran](https://github.com/hfaran)
 
 
 ## Contributors
 
-* Philip Mallory [@pmallory](github.com/pmallory)
+* Philip Mallory [@pmallory](https://github.com/pmallory)
     * Enroll users
     * Get all users
     * Remove users
 
-* Ben Cook [@blx](github.com/blx)
+* Ben Cook [@blx](https://github.com/blx)
     * Get users
     * `PiazzaRPC.request`
     * [`Piazza.get_user_classes`](https://github.com/hfaran/piazza-api/pull/22)


### PR DESCRIPTION
Hey, just noticed that these links to GH profiles don't seem to work without a full address -- `github.com/{user}` was interpreted as a relative link to the current location, giving `https://github.com/hfaran/piazza-api/blob/develop/github.com/{user}` and so on.