### PR TITLE
feat(user): Add followup-creating functionality.

### DIFF
--- a/piazza_api/__init__.py
+++ b/piazza_api/__init__.py
@@ -1,3 +1,3 @@
 from piazza_api.piazza import Piazza
 
-__version__ = "0.4.2"
+__version__ = "0.4.1"

--- a/piazza_api/__init__.py
+++ b/piazza_api/__init__.py
@@ -1,3 +1,3 @@
 from piazza_api.piazza import Piazza
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -114,7 +114,7 @@ class Network(object):
 
         :type  post: dict|str|int
         :param post: Either the post dict returned by another API method, or
-            the cid` field of that post.
+            the `cid` field of that post.
         :type  subject: str
         :param content: The content of the followup.
         :type  anonymous: bool

--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -105,6 +105,40 @@ class Network(object):
         for cid in cids:
             yield self.get_post(cid)
 
+    def create_followup(self, post, content, anonymous=False):
+        """Create a follow-up on a post `post`.
+
+        It seems like if the post has `<p>` tags, then it's treated as HTML,
+        but is treated as text otherwise. You'll want to provide `content`
+        accordingly.
+
+        :type  post: dict|str|int
+        :param post: Either the post dict returned by another API method, or
+            the cid` field of that post.
+        :type  subject: str
+        :param content: The content of the followup.
+        :type  anonymous: bool
+        :param anonymous: Whether or not to post anonymously.
+        :rtype: dict
+        :returns: Dictionary with information about the created follow-up.
+        """
+        try:
+            cid = post["id"]
+        except KeyError:
+            cid = post
+
+        params = {
+            "cid": cid,
+            "type": "followup",
+
+            # For followups, the content is actually put into the subject.
+            "subject": content,
+            "content": "",
+
+            "anonymous": "yes" if anonymous else "no",
+        }
+        return self._rpc.content_create(params)
+
     #########
     # Users #
     #########

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -96,6 +96,22 @@ class PiazzaRPC(object):
         )
         return self._handle_error(r, "Could not get post {}.".format(cid))
 
+    def content_create(self, params):
+        """Create a post or followup.
+
+        :type  params: dict
+        :param params: A dict of options to pass to the endpoint. Depends on
+            the specific type of content being created.
+        :returns: Python object containing returned data
+        """
+        r = self.request(
+            method="content.create",
+            # blank.
+            data=params
+        )
+        return self._handle_error(r, "Could not create object {}.".format(
+                                     repr(params)))
+
     def add_students(self, student_emails, nid=None):
         """Enroll students in a network `nid`.
 

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -106,7 +106,6 @@ class PiazzaRPC(object):
         """
         r = self.request(
             method="content.create",
-            # blank.
             data=params
         )
         return self._handle_error(r, "Could not create object {}.".format(


### PR DESCRIPTION
Hi! It didn't look like the ability to post a follow-up existed, so I added it. Here's a picture of it in action:

![screen shot 2015-05-23 at 8 52 14 pm](https://cloud.githubusercontent.com/assets/454057/7786663/eb72231e-0191-11e5-9554-6afe2f938af4.png)
