### PR TITLE
feat(user): added support for marking two posts as duplicates

### DIFF
--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -173,6 +173,27 @@ class Network(object):
         }
         return self._rpc.content_instructor_answer(params)
 
+    def mark_as_duplicate(self, duplicated_cid, master_cid, msg=''):
+        """Mark the post at DUPLICATED_CID as a duplicate of MASTER_CID
+
+        :type  duplicated_cid: int
+        :param duplicated_cid: The numeric id of the duplicated post
+        :type  master_cid: int
+        :param master_cid: The numeric id of an older post. This will be the
+            post that gets kept and DUPLICATED_CID post will be concatinated
+            as a follow up to MASTER_CID post.
+        :returns True if it is successful. False otherwise
+        """
+        try:
+            content_id_from = self.get_post(duplicated_cid)['id']
+            content_id_to = self.get_post(master_cid)['id']
+        except:
+            return False
+        params = {'cid_dupe': content_id_from,
+                'cid_to': content_id_to,
+                'msg': msg}
+        return self._rpc.content_mark_duplicate(params) == 'OK'
+
     #########
     # Users #
     #########

--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -174,25 +174,26 @@ class Network(object):
         return self._rpc.content_instructor_answer(params)
 
     def mark_as_duplicate(self, duplicated_cid, master_cid, msg=''):
-        """Mark the post at DUPLICATED_CID as a duplicate of MASTER_CID
+        """Mark the post at ``duplicated_cid`` as a duplicate of ``master_cid``
 
         :type  duplicated_cid: int
         :param duplicated_cid: The numeric id of the duplicated post
         :type  master_cid: int
         :param master_cid: The numeric id of an older post. This will be the
-            post that gets kept and DUPLICATED_CID post will be concatinated
-            as a follow up to MASTER_CID post.
-        :returns True if it is successful. False otherwise
+            post that gets kept and ``duplicated_cid`` post will be concatinated
+            as a follow up to ``master_cid`` post.
+        :type msg: string
+        :param msg: the optional message (or reason for marking as duplicate)
+        :returns: True if it is successful. False otherwise
         """
-        try:
-            content_id_from = self.get_post(duplicated_cid)['id']
-            content_id_to = self.get_post(master_cid)['id']
-        except:
-            return False
-        params = {'cid_dupe': content_id_from,
-                'cid_to': content_id_to,
-                'msg': msg}
-        return self._rpc.content_mark_duplicate(params) == 'OK'
+        content_id_from = self.get_post(duplicated_cid)["id"]
+        content_id_to = self.get_post(master_cid)["id"]
+        params = {
+            "cid_dupe": content_id_from,
+            "cid_to": content_id_to,
+            "msg": msg
+        }
+        return self._rpc.content_mark_duplicate(params)
 
     #########
     # Users #

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -127,6 +127,19 @@ class PiazzaRPC(object):
         return self._handle_error(r, "Could not create object {}.".format(
                                      repr(params)))
 
+    def content_mark_duplicate(self, params):
+        """Mark a post as duplicate to another.
+
+        :type params: dict
+        :param params: the parameters to be passed in
+        :returns python object containting returned data
+        """
+        r = self.request(
+                method="content.duplicate",
+                data=params
+        )
+        return self._handle_error(r, "Could not create object {}.".format(
+                                     repr(params)))
 
     def add_students(self, student_emails, nid=None):
         """Enroll students in a network `nid`.

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -109,8 +109,10 @@ class PiazzaRPC(object):
             method="content.create",
             data=params
         )
-        return self._handle_error(r, "Could not create object {}.".format(
-                                     repr(params)))
+        return self._handle_error(
+            r,
+            "Could not create object {}.".format(repr(params))
+        )
 
     def content_instructor_answer(self, params):
         """Answer a post as an instructor.
@@ -132,11 +134,10 @@ class PiazzaRPC(object):
 
         :type params: dict
         :param params: the parameters to be passed in
-        :returns python object containting returned data
         """
         r = self.request(
-                method="content.duplicate",
-                data=params
+            method="content.duplicate",
+            data=params
         )
         return self._handle_error(r, "Could not create object {}.".format(
                                      repr(params)))


### PR DESCRIPTION
This commit adds support for marking two posts as duplicates. Might be useful than just posting duplicated answer or @ the post

Resolves #35
