### PR TITLE
fix(dev): Fix 'Request not valid' error due to piazza API changes

### DIFF
--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -367,14 +367,19 @@ class PiazzaRPC(object):
         nid = nid if nid else self._nid
         if data is None:
             data = {}
-
+        
+        headers = {}
+        if "session_id" in self.cookies:
+            headers['CSRF-Token'] = self.cookies["session_id"]
+        
         response = requests.post(
             self.base_api_urls[api_type],
             data=json.dumps({
                 "method": method,
                 "params": dict({nid_key: nid}, **data)
             }),
-            cookies=self.cookies
+            cookies=self.cookies,
+            headers = headers
         )
         return response if return_response else response.json()
 


### PR DESCRIPTION
Due to recent changes to how Piazza structures and verifies API calls, this unofficial API no longer works. Every request responds with the error "Request not valid" even after proper authentication. This PR remediates this by passing up an expected CSRF-Token header which is populated with the value of the "session_id" cookie the API responds with. 