### PR TITLE
fix(dev): Added support for the Piazza API nonce "aid" introduced recently.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,18 +9,21 @@
 
 ## Contributors
 
-* Philip Mallory [@pmallory](https://github.com/pmallory)
-    * Enroll users
-    * Get all users
-    * Remove users
-
 * Ben Cook [@blx](https://github.com/blx)
     * Get users
     * `PiazzaRPC.request`
     * [`Piazza.get_user_classes`](https://github.com/hfaran/piazza-api/pull/22)
 
 * Waleed Khan [@arxanas](https://github.com/arxanas)
-    - [`Network.create_followup`](https://github.com/hfaran/piazza-api/pull/25)
+    * [`Network.create_followup`](https://github.com/hfaran/piazza-api/pull/25)
+
+* Jérémie Lumbroso [@jlumbroso](https://github.com/jlumbroso)
+    * Support for nonces (`aid`)
+
+* Philip Mallory [@pmallory](https://github.com/pmallory)
+    * Enroll users
+    * Get all users
+    * Remove users
 
 * David Snider [@DavidSnider](https://github.com/DavidSnider)
-    - [feat(user): Add answer-creating functionality](https://github.com/hfaran/piazza-api/pull/31)
+    * [feat(user): Add answer-creating functionality](https://github.com/hfaran/piazza-api/pull/31)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@
 
 * Jérémie Lumbroso [@jlumbroso](https://github.com/jlumbroso)
     * Support for nonces (`aid`)
+    * Added ``get_user_status`` and fixed retrieval of user classes (``get_user_classes``).
 
 * Philip Mallory [@pmallory](https://github.com/pmallory)
     * Enroll users

--- a/piazza_api/nonce.py
+++ b/piazza_api/nonce.py
@@ -1,0 +1,60 @@
+from time import time as _time
+from random import random as _random
+
+from string import digits as _digits
+from string import ascii_letters as _ascii_letters
+
+def nonce():
+    """
+    Returns a new nonce to be used with the Piazza API.
+    """
+    nonce_part1 = _int2base(int(_time()*1000), 36) 
+    nonce_part2 = _int2base(round(_random()*1679616), 36)
+    return "{}{}".format(nonce_part1, nonce_part2)
+
+# Code adapted from:
+# https://stackoverflow.com/a/2267446/408734
+
+_exradix_digits = _digits + _ascii_letters
+
+def _int2base(x, base):
+    """
+    Converts an integer from base 10 to some arbitrary numerical base,
+    and return a string representing the number in the new base (using
+    letters to extend the numerical digits).
+
+    :type     x: int
+    :param    x: The integer to convert
+    :type  base: int
+    :param base: The base to convert the integer to
+    :rtype: str
+    :returns: Dictionary with all data on the post
+    """
+    
+    if base > len(_exradix_digits):
+        raise ValueError(
+            "Base is too large: The defined digit set only allows for "
+            "bases smaller than " + len(_exradix_digits) + "."
+        )
+
+    if x > 0:
+        sign = 1
+    elif x == 0:
+        return _exradix_digits[0]
+    else:
+        sign = -1
+
+    x *= sign
+    digits = []
+
+    while x:
+        digits.append(
+            _exradix_digits[int(x % base)])
+        x = int(x / base)
+
+    if sign < 0:
+        digits.append('-')
+
+    digits.reverse()
+
+    return ''.join(digits)

--- a/piazza_api/piazza.py
+++ b/piazza_api/piazza.py
@@ -64,8 +64,8 @@ class Piazza(object):
         return self._rpc_api.get_user_status()
 
     def get_user_classes(self):
-        """Get list of the current user's classes. This is a subset of
-        ``get_user_status``.
+        """Get list of the current user's classes. This is a subset of the
+        information returned by the call to ``get_user_status``.
 
         :returns: Classes of currently authenticated user
         :rtype: list

--- a/piazza_api/piazza.py
+++ b/piazza_api/piazza.py
@@ -65,16 +65,21 @@ class Piazza(object):
 
     def get_user_classes(self):
         """Get list of the current user's classes. This is a subset of
-        ``get_user_profile``.
+        ``get_user_status``.
 
         :returns: Classes of currently authenticated user
         :rtype: list
         """
-        raw_classes = self.get_user_profile().get('all_classes').values()
+        # Previously getting classes from profile (such a list is incomplete)
+        # raw_classes = self.get_user_profile().get('all_classes').values()
+
+        # Get classes from the user status (includes all classes)
+        raw_classes = self.get_user_status().get('networks', [])
 
         classes = []
         for rawc in raw_classes:
-            c = {k: rawc[k] for k in ['name', 'num', 'term']}
+            c = {k: rawc[k] for k in ['name', 'term']}
+            c['num'] = rawr.get('course_number', '')
             c['nid'] = rawc['id']
             c['is_ta'] = rawc.get('is_ta', False)
             classes.append(c)

--- a/piazza_api/piazza.py
+++ b/piazza_api/piazza.py
@@ -52,6 +52,16 @@ class Piazza(object):
         :rtype: dict
         """
         return self._rpc_api.get_user_profile()
+    
+    def get_user_status(self):
+        """
+        Get global status of the current user, which contains information on
+        the relationship of the user with respect to all their enrolled classes.
+
+        :returns: Status of currently authenticated user
+        :rtype: dict
+        """
+        return self._rpc_api.get_user_status()
 
     def get_user_classes(self):
         """Get list of the current user's classes. This is a subset of

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -7,6 +7,8 @@ import six.moves
 from piazza_api.exceptions import AuthenticationError, NotAuthenticatedError, \
     RequestError
 
+from piazza_api.nonce import nonce as _piazza_nonce
+
 
 class PiazzaRPC(object):
     """Unofficial Client for Piazza's Internal API
@@ -371,9 +373,17 @@ class PiazzaRPC(object):
         headers = {}
         if "session_id" in self.cookies:
             headers["CSRF-Token"] = self.cookies["session_id"]
+        
+        # Adding a nonce to the request
+        endpoint = self.base_api_urls[api_type]
+        if api_type == "logic":
+            endpoint += "?method={}&aid={}".format(
+                method,
+                _piazza_nonce()
+            )
 
         response = requests.post(
-            self.base_api_urls[api_type],
+            endpoint,
             data=json.dumps({
                 "method": method,
                 "params": dict({nid_key: nid}, **data)

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -343,6 +343,14 @@ class PiazzaRPC(object):
         r = self.request(method="user_profile.get_profile")
         return self._handle_error(r, "Could not get user profile.")
 
+    def get_user_status(self):
+        """
+        Get global status of the current user, which contains information on
+        the relationship of the user with respect to all their enrolled classes.
+        """
+        r = self.request(method="user.status")
+        return self._handle_error(r, "Could not get user status.")
+
     def request(self, method, data=None, nid=None, nid_key='nid',
                 api_type="logic", return_response=False):
         """Get data from arbitrary Piazza API endpoint `method` in network `nid`


### PR DESCRIPTION
Added support for the nonces that the Piazza API uses, see for instance [line 14-15 of this script](https://piazza.com/modules/ajax.js?v=2274):
>  var API_URL = '/logic/api?method=generic.report_js_error&aid=' +
>    (new Date()).getTime().toString(36) + Math.round(Math.random() * 1679616).toString(36);

I abstracted this functionality in a separate `nonce.py` submodule and integrated in the `rpc.py` ``request`` function which actually places the API requests, so that all methods are "signed" in this way.

(PS: Many thanks for the open source implementation of this API wrapper!)