### PR TITLE
fix(dev): Use requests.Session object for updating cookies

### DIFF
--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -47,12 +47,13 @@ class Network(object):
     """Abstraction for a Piazza "Network" (or class)
 
     :param network_id: ID of the network
-    :param cookies: RequestsCookieJar containing cookies used for authentication
+    :param session: requests.Session object containing cookies used for
+        authentication
     """
-    def __init__(self, network_id, cookies):
+    def __init__(self, network_id, session):
         self._nid = network_id
         self._rpc = PiazzaRPC(network_id=self._nid)
-        self._rpc.cookies = cookies
+        self._rpc.session = session
 
         ff = namedtuple('FeedFilters', ['unread', 'following', 'folder'])
         self._feed_filters = ff(UnreadFilter, FollowingFilter, FolderFilter)

--- a/piazza_api/piazza.py
+++ b/piazza_api/piazza.py
@@ -43,7 +43,7 @@ class Piazza(object):
             https://piazza.com/class/{network_id}
         """
         self._ensure_authenticated()
-        return Network(network_id, self._rpc_api.cookies)
+        return Network(network_id, self._rpc_api.session)
 
     def get_user_profile(self):
         """Get profile of the current user

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -31,7 +31,7 @@ class PiazzaRPC(object):
             "logic": "https://piazza.com/logic/api",
             "main": "https://piazza.com/main/api",
         }
-        self.cookies = None
+        self.session = requests.Session()
 
     def user_login(self, email=None, password=None):
         """Login with email, password and get back a session cookie
@@ -51,14 +51,13 @@ class PiazzaRPC(object):
         }
         # If the user/password match, the server respond will contain a
         #  session cookie that you can use to authenticate future requests.
-        r = requests.post(
+        r = self.session.post(
             self.base_api_urls["logic"],
             data=json.dumps(login_data),
         )
         if r.json()["result"] not in ["OK"]:
             raise AuthenticationError("Could not authenticate.\n{}"
                                       .format(r.json()))
-        self.cookies = r.cookies
 
     def demo_login(self, auth=None, url=None):
         """Authenticate with a "Share Your Class" URL using a demo user.
@@ -76,10 +75,9 @@ class PiazzaRPC(object):
         if url is None:
             url = "https://piazza.com/demo_login"
             params = dict(nid=self._nid, auth=auth)
-            res = requests.get(url, params=params)
+            res = self.session.get(url, params=params)
         else:
-            res = requests.get(url)
-        self.cookies = res.cookies
+            res = self.session.get(url)
 
     def content_get(self, cid, nid=None):
         """Get data from post `cid` in network `nid`
@@ -379,9 +377,9 @@ class PiazzaRPC(object):
             data = {}
 
         headers = {}
-        if "session_id" in self.cookies:
-            headers["CSRF-Token"] = self.cookies["session_id"]
-        
+        if "session_id" in self.session.cookies:
+            headers["CSRF-Token"] = self.session.cookies["session_id"]
+
         # Adding a nonce to the request
         endpoint = self.base_api_urls[api_type]
         if api_type == "logic":
@@ -390,13 +388,12 @@ class PiazzaRPC(object):
                 _piazza_nonce()
             )
 
-        response = requests.post(
+        response = self.session.post(
             endpoint,
             data=json.dumps({
                 "method": method,
                 "params": dict({nid_key: nid}, **data)
             }),
-            cookies=self.cookies,
             headers=headers
         )
         return response if return_response else response.json()
@@ -410,7 +407,7 @@ class PiazzaRPC(object):
 
         :raises: NotAuthenticatedError
         """
-        if self.cookies is None:
+        if not self.session.cookies:
             raise NotAuthenticatedError("You must authenticate before "
                                         "making any other requests.")
 


### PR DESCRIPTION
Before, we were not keeping track of cookie updates being sent by the Piazza API when making requests. This is normally not an issue, but presents a problem when a machine is making multiple requests to the Piazza API for different networks. Imagine running a crawler for two courses: when the second crawler begins crawling a different course, the sessions for both crawlers become invalid because the server must be sending updated cookies for them both in response to content.get calls. By using a session object to make our requests, we can more simply ensure that the cookies stay up to date, and this fixes the issues with multiple crawlers on one machine.