### PR TITLE
fix(dev): repair is_ta boolean in get_user_classes

### DIFF
--- a/piazza_api/piazza.py
+++ b/piazza_api/piazza.py
@@ -74,14 +74,16 @@ class Piazza(object):
         # raw_classes = self.get_user_profile().get('all_classes').values()
 
         # Get classes from the user status (includes all classes)
-        raw_classes = self.get_user_status().get('networks', [])
+        status = self.get_user_status()
+        uid = status['id']
+        raw_classes = status.get('networks', [])
 
         classes = []
         for rawc in raw_classes:
             c = {k: rawc[k] for k in ['name', 'term']}
             c['num'] = rawc.get('course_number', '')
             c['nid'] = rawc['id']
-            c['is_ta'] = rawc.get('is_ta', False)
+            c['is_ta'] = uid in rawc['prof_hash']
             classes.append(c)
 
         return classes


### PR DESCRIPTION
`is_ta` appears to be no longer sent in the networks list of `user.status`, so instead we use the `profs_hash` to check for TA status. (Not sure when this change was made on Piazza's side, but all of a sudden it was always false for me.)