### PR TITLE
Update post functionality

### DIFF
--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -260,10 +260,11 @@ class Network(object):
             cid = post["id"]
         except KeyError:
             cid = post
+        except TypeError:
+            cid = post
 
         params = {
             "cid": cid,
-
             # For updates, the content is put into the subject.
             "subject": content,
         }

--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -245,6 +245,30 @@ class Network(object):
         }
         return self._rpc.content_create(params)
 
+    def update_post(self, post, content):
+        """Update post content by cid
+
+        :type  post: dict|str|int
+        :param post: Either the post dict returned by another API method, or
+            the `cid` field of that post.
+        :type  subject: str
+        :param content: The content of the followup.
+        :rtype: dict
+        :returns: Dictionary with information about the updated post.
+        """
+        try:
+            cid = post["id"]
+        except KeyError:
+            cid = post
+
+        params = {
+            "cid": cid,
+
+            # For updates, the content is put into the subject.
+            "subject": content,
+        }
+        return self._rpc.content_update(params)
+
     def mark_as_duplicate(self, duplicated_cid, master_cid, msg=''):
         """Mark the post at ``duplicated_cid`` as a duplicate of ``master_cid``
 
@@ -305,6 +329,30 @@ class Network(object):
         }
 
         return self._rpc.content_pin(params)
+
+    def delete_post(self, post):
+        """ Deletes post by cid
+
+        :type  post: dict|str|int
+        :param post: Either the post dict returned by another API method, the post ID, or
+            the `cid` field of that post.
+        :rtype: dict
+        :returns: Dictionary with information about the post cid.
+        """
+
+        try:
+            cid = post['id']
+        except KeyError:
+            cid = post
+        except TypeError:
+            post = self.get_post(post)
+            cid = post['id']
+
+        params = {
+            "cid": cid,
+        }
+
+        return self._rpc.content_delete(params)
 
     #########
     # Users #
@@ -374,30 +422,6 @@ class Network(object):
             the network after users are removed.
         """
         return self._rpc.remove_users(user_ids=user_ids)
-
-    def delete_post(self, post):
-        """ Deletes post by cid
-
-        :type  post: dict|str|int
-        :param post: Either the post dict returned by another API method, the post ID, or
-            the `cid` field of that post.
-        :rtype: dict
-        :returns: Dictionary with information about the post cid.
-        """
-
-        try:
-            cid = post['id']
-        except KeyError:
-            cid = post
-        except TypeError:
-            post = self.get_post(post)
-            cid = post['id']
-
-        params = {
-            "cid": cid,
-        }
-
-        return self._rpc.content_delete(params)
 
     ########
     # Feed #

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -114,6 +114,23 @@ class PiazzaRPC(object):
             "Could not create object {}.".format(repr(params))
         )
 
+    def content_update(self, params):
+        """Update a post or followup.
+
+        :type  params: dict
+        :param params: A dict of options to pass to the endpoint. Depends on
+            the specific type of content being created.
+        :returns: Python object containing returned data
+        """
+        r = self.request(
+            method="content.update",
+            data=params
+        )
+        return self._handle_error(
+            r,
+            "Could not create object {}.".format(repr(params))
+        )
+
     def content_instructor_answer(self, params):
         """Answer a post as an instructor.
 


### PR DESCRIPTION
This pull request includes additional functionality which allows users to update an existing post by passing in _post id_ or _post dict_. The following additions/changes are included:

- In rpc.py- Added the **content_update** method
- In network.py - Added **update_post** method, which updates post content by cid or post dict
- In network.py - The **delete_post** method was in the wrong section. I moved the delete_post method to the correct section ("Posts")