### PR TITLE
Add student_view param to content.get

### DIFF
--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -92,7 +92,7 @@ class PiazzaRPC(object):
         """
         r = self.request(
             method="content.get",
-            data={"cid": cid},
+            data={"cid": cid, "student_view": "false"},
             nid=nid
         )
         return self._handle_error(r, "Could not get post {}.".format(cid))


### PR DESCRIPTION
The `content.get` endpoint was broken for me, and adding a `student_view: false` parameter made it work. I'm not exactly sure what this parameter does.