### PR TITLE
Added ability to unpin posts

### DIFF
--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -315,12 +315,13 @@ class Network(object):
 
         return self._rpc.content_mark_resolved(params)
 
-    def pin_post(self, post):
-        """Pin post
+    def pin_post(self, post, unpin=False):
+        """Pin/Unpin post
 
         :type  post: dict|str|int
         :param post: Either the post dict returned by another API method, or
             the `cid` field of that post.
+        :param unpin: Whether the post should be unpinned.
         :returns: True if it is successful. False otherwise
         """
         try:
@@ -332,7 +333,7 @@ class Network(object):
             "cid": cid,
         }
 
-        return self._rpc.content_pin(params)
+        return self._rpc.content_pin(params, unpin=unpin)
 
     def delete_post(self, post):
         """ Deletes post by cid

--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -219,14 +219,16 @@ class PiazzaRPC(object):
         return self._handle_error(r, "Could not create object {}.".format(
                                      repr(params)))
 
-    def content_pin(self, params):
-        """Pin a post
+    def content_pin(self, params, unpin=False):
+        """Pin/Unpin a post
 
         :type params: dict
         :param params: the parameters to be passed in
+        :param unpin: Whether the post should be unpinned
         """
+        method = "content.unpin" if unpin else "content.pin"
         r = self.request(
-            method="content.pin",
+            method=method,
             data=params
         )
         return self._handle_error(r, "Could not create object {}.".format(


### PR DESCRIPTION
The content.unpin method exists to unpin Piazza posts. Adding a keyword
argument to the pin method lets us use this functionality without
creating a new method.