### PR TITLE
Implement add instructor follow up

### DIFF
--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -152,7 +152,7 @@ class Network(object):
 
         return self._rpc.content_create(params)
 
-    def create_followup(self, post, content, anonymous=False):
+    def create_followup(self, post, content, anonymous=False, instructor=False):
         """Create a follow-up on a post `post`.
 
         It seems like if the post has `<p>` tags, then it's treated as HTML,
@@ -177,11 +177,14 @@ class Network(object):
         params = {
             "cid": cid,
             "type": "followup",
-
+            
             # For followups, the content is actually put into the subject.
             "subject": content,
             "content": "",
-
+            "config": {
+                "editor": "rte",
+                "ionly": True if instructor else False,
+            },
             "anonymous": "yes" if anonymous else "no",
         }
         return self._rpc.content_create(params)


### PR DESCRIPTION
## Description

This PR adds a simple feature to add instructor follow-ups to posts. Developed this because I require being able to use an account to post GPT answers to questions that TAs can approve, that should not be visible to students. Hence the need for an instructor follow-up. May be too trivial to include in the API, but thought it would be useful as EdTech and GenAI use cases become more popular on course forums. 

Usage
This simple program demonstrates how to use the create_followup() function to add a follow-up that is only visible to instructors:

```python
from piazza_api import Piazza

# Instantiate a Piazza object
p = Piazza()

# Login to Piazza
p.user_login(email="XYZ@uni.edu", password="ABC123")

# Connect to the class
class_id = "PiazzaClassID"  
network = p.network(class_id)

# Get the post
post_number = 123
post = network.get_post(post_number)

# Create a follow-up
followup_content = "This is a follow-up post."
network.create_followup(post, followup_content, instructor=True)
```

Here is an example: 

<img width="1124" alt="image" src="https://github.com/hfaran/piazza-api/assets/30690855/b7500d23-a14a-4797-903a-22d1e9782e42">
