### PR TITLE
Update user_login method to submit form data as dictionary instead of str.format()

### DIFF
--- a/piazza_api/rpc.py
+++ b/piazza_api/rpc.py
@@ -77,8 +77,14 @@ class PiazzaRPC(object):
 
         # Log in using credentials and CSRF token and store cookie in session
         response = self.session.post(
-            'https://piazza.com/class', 
-            data=r'from=%2Fsignup&email={0}&password={1}&remember=on&csrf_token={2}'.format(email, password, csrf_token)
+            "https://piazza.com/class",
+            data={
+                "from": "/signup",
+                "email": email,
+                "password": password,
+                "remember": "on",
+                "csrf_token": csrf_token,
+            },
         )
 
         # If non-successful http response, bail


### PR DESCRIPTION
Currently the `user_login` method uses manual string formatting to generate the login form data:
https://github.com/hfaran/piazza-api/blob/acb5de9987d2502fedc11f57003e6aa9805c77e1/piazza_api/rpc.py#L81

This is generally not a good idea because it doesn’t correctly form-encode/escape special characters. This means that, for example, passwords containing special characters (e.g. `/`, `&`, `=`) will break the login flow, because they mess up the form syntax instead of being correctly encoded (e.g. `%2f`, `%26`, `%3d`). Aliased email addresses like `user+alias@gmail.com` will also fail, because the `+` gets interpreted as an escaped space character instead of a literal `+` in the email. The more correct thing to do here is to pass in the data as a dictionary; this way the data is automatically form-encoded:

> `data` – the body to attach to the request. If a dictionary or list of tuples `[(key, value)]` is provided, form-encoding will take place.
> https://docs.python-requests.org/en/latest/api/#requests.Request
