### PR TITLE
feat: Add support for private posts to instructors

### DIFF
--- a/piazza_api/network.py
+++ b/piazza_api/network.py
@@ -111,7 +111,7 @@ class Network(object):
             time.sleep(sleep)
             yield self.get_post(cid)
 
-    def create_post(self, post_type, post_folders, post_subject, post_content, is_announcement=0, bypass_email=0, anonymous=False):
+    def create_post(self, post_type, post_folders, post_subject, post_content, is_announcement=0, bypass_email=0, anonymous=False, is_private=False):
         """Create a post
 
         It seems like if the post has `<p>` tags, then it's treated as HTML,
@@ -132,6 +132,8 @@ class Network(object):
         :param bypass_email:
         :type anonymous: bool
         :param anonymous:
+        :type is_private: bool
+        :param is_private: If True, post will be private to instructors only.
         :rtype: dict
         :returns: Dictionary with information about the created post.
         """
@@ -146,6 +148,12 @@ class Network(object):
                 "is_announcement": is_announcement
             }
         }
+
+        if is_private:
+            user_profile = self._rpc.get_user_profile() or {}
+            user_id = user_profile.get('user_id')
+            if user_id:
+                params["config"]["feed_groups"] = f"instr_{self._nid},{user_id}" 
 
         if bypass_email:
             params["prof_override"] = True


### PR DESCRIPTION
Hello! Thanks for this great library. I've added a feature to allow creating posts that are private to instructors, which is a common use case on Piazza.

**What This PR Does**
- Adds a new optional boolean parameter, is_private, to the Network.create_post() method.
- When is_private=True, the method now constructs the necessary payload to make the post visible only to instructors and the user creating the post.

**How it Works**
While investigating how to implement this, I used my browser's network inspector to analyze the API call made by the official Piazza website when creating a private post.

I discovered that Piazza doesn't use a simple private: true flag. Instead, it requires a feed_groups key inside the config object. The value for this key is a comma-separated string containing: 
1. The identifier for all instructors (instr_{class_id}).
2. The user ID of the person creating the post (so they can also see it).
 
This implementation replicates that exact behavior: 
- It fetches the current user's profile to get their user_id.
- It constructs the feed_groups string dynamically (e.g., "instr_...abc,user_...123").
- It adds this to the params dictionary sent to the API.

If is_private is False (the default), the method's behavior is unchanged. 

**Example Usage**
```python
# Create a public post (current behavior)
course.create_post(..., is_private=False) 

# Create a new private post visible only to instructors
course.create_post(..., is_private=True)
```
